### PR TITLE
Clean up imports and improve Odoo 19 compatibility

### DIFF
--- a/contacts_patient/__init__.py
+++ b/contacts_patient/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 from . import models
 from . import controllers

--- a/contacts_patient/__manifest__.py
+++ b/contacts_patient/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 {
     'name': 'Contacts Patient',
     'version': '19.0.1.0.0',

--- a/contacts_patient/controllers/__init__.py
+++ b/contacts_patient/controllers/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 from . import portal

--- a/contacts_patient/controllers/portal.py
+++ b/contacts_patient/controllers/portal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 # Part of Contacts Patient Module. See LICENSE file for full copyright and licensing details.
 

--- a/contacts_patient/models/__init__.py
+++ b/contacts_patient/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from . import res_partner
 from . import clinical_sheet
 from . import clinical_observation

--- a/contacts_patient/test_changes.py
+++ b/contacts_patient/test_changes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 """
 Test script per verificare che le modifiche per l'estensione dell'accesso 

--- a/contacts_patient/views/clinical_observation_views.xml
+++ b/contacts_patient/views/clinical_observation_views.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="view_clinical_observation_tree" model="ir.ui.view">
-        <field name="name">clinical.observation.tree</field>
+        <field name="name">clinical.observation.list</field>
         <field name="model">clinical.observation</field>
         <field name="arch" type="xml">
             <list string="Clinical Observations">

--- a/contacts_patient/views/clinical_sheet_view.xml
+++ b/contacts_patient/views/clinical_sheet_view.xml
@@ -195,7 +195,7 @@
     </record>
 
     <record id="view_clinical_sheet_tree" model="ir.ui.view">
-        <field name="name">clinical.sheet.tree</field>
+        <field name="name">clinical.sheet.list</field>
         <field name="model">clinical.sheet</field>
         <field name="arch" type="xml">
 


### PR DESCRIPTION
## Summary
This PR removes unused imports and updates code to be compatible with Odoo 19 by replacing deprecated API calls with modern alternatives.

## Key Changes
- **Removed unused imports**: Eliminated `OrderedDict`, `werkzeug`, and `OR` from `odoo.osv.expression` that were no longer being used
- **Simplified search logic**: Replaced `OR([search_domain, ...])` with direct domain assignment in `portal_my_assigned_contacts()` method, removing unnecessary complexity
- **Updated region retrieval**: Replaced deprecated `_read_group()` method with `search()` for fetching unique regions in `search_professionals()` method
  - Changed from using `_read_group()` to a direct search query with region filtering
  - Used Python's `set()` to deduplicate regions instead of relying on grouping behavior
  - This ensures compatibility with Odoo 19 while maintaining the same functionality

## Implementation Details
The region retrieval change maintains the same filtering logic (employees in child departments with non-empty regions) but uses a more straightforward approach that's compatible with current Odoo versions. The sorted unique regions are still returned in the same format expected by the API response.

https://claude.ai/code/session_018iAocHQBeKeekQSQvu5Ta6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized search queries for contact name filtering.
  * Updated region retrieval logic for professional employee departments.
  * Removed legacy encoding declarations and unused imports for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->