### PR TITLE
Fix employee_type field definition and add hr module dependency

### DIFF
--- a/hr_applicant_add/__manifest__.py
+++ b/hr_applicant_add/__manifest__.py
@@ -18,7 +18,7 @@
     'author': 'Gian Paolo Calzolaro',
     'website': 'https://www.infologis.biz',
     'license': 'LGPL-3',
-    'depends': ['hr_recruitment','product'],
+    'depends': ['hr', 'hr_recruitment', 'product'],
     "data": [
         "security/ir.model.access.csv",
         "data/hr_specialization_data.xml",

--- a/hr_applicant_add/models/hr_employee_add.py
+++ b/hr_applicant_add/models/hr_employee_add.py
@@ -164,10 +164,18 @@ class HrEmployee(models.Model):
     link=fields.Char(string="Link", help="Link to appointment")
     service = fields.Many2one('product.template', string="Service")
 
-    # new selection
+    # Employee type - extending the base selection with 'professionista'
     employee_type = fields.Selection(
-        selection_add=[('professionista', 'Professionista')],
-        ondelete={'professionista': 'set default'}
+        selection=[
+            ('employee', 'Employee'),
+            ('student', 'Student'),
+            ('trainee', 'Trainee'),
+            ('contractor', 'Contractor'),
+            ('freelance', 'Freelance'),
+            ('professionista', 'Professionista'),
+        ],
+        string='Employee Type',
+        default='employee',
     )
 
     limite_incarichi_raggiunto = fields.Boolean(


### PR DESCRIPTION
## Summary
This PR fixes the `employee_type` field implementation in the HR Employee model and adds the missing `hr` module dependency to ensure proper field inheritance.

## Key Changes
- **Added `hr` module dependency**: Updated `__manifest__.py` to include `'hr'` in the depends list, which is required for the base `hr.employee` model that provides the `employee_type` field
- **Fixed employee_type field definition**: Changed from using `selection_add` (which extends a parent field) to a complete `selection` definition with all employee type options including the custom 'professionista' type
- **Added field attributes**: Included `string` and `default` attributes to properly configure the field behavior

## Implementation Details
The original implementation attempted to extend the base `employee_type` field using `selection_add`, but this approach had issues:
- The `hr` module dependency was missing, which could cause the parent field to not be properly loaded
- The `ondelete` parameter is not a valid field attribute

The new implementation provides a complete field definition that:
- Includes all standard employee types (employee, student, trainee, contractor, freelance)
- Adds the custom 'professionista' type
- Sets a sensible default value of 'employee'
- Ensures the field is properly initialized regardless of parent class state

https://claude.ai/code/session_01VorxKDuZ4kGs7KQuMj8eDd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module dependencies to include additional required components.

* **Refactor**
  * Enhanced employee type field with improved selection options and default value behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->