### PR TITLE
[FIX] hr_applicant_add: Use method-based selection for employee_type …

### DIFF
--- a/hr_applicant_add/models/hr_employee_add.py
+++ b/hr_applicant_add/models/hr_employee_add.py
@@ -164,16 +164,21 @@ class HrEmployee(models.Model):
     link=fields.Char(string="Link", help="Link to appointment")
     service = fields.Many2one('product.template', string="Service")
 
-    # Employee type - extending the base selection with 'professionista'
-    employee_type = fields.Selection(
-        selection=[
+    @api.model
+    def _get_employee_type_selection(self):
+        """Return selection options for employee_type field (lazy evaluation for Odoo 19)."""
+        return [
             ('employee', 'Employee'),
             ('student', 'Student'),
             ('trainee', 'Trainee'),
             ('contractor', 'Contractor'),
             ('freelance', 'Freelance'),
             ('professionista', 'Professionista'),
-        ],
+        ]
+
+    # Employee type - using method-based selection for Odoo 19 compatibility
+    employee_type = fields.Selection(
+        selection='_get_employee_type_selection',
         string='Employee Type',
         default='employee',
     )


### PR DESCRIPTION
…(Odoo 19)

Fix AssertionError: Field hr.employee.employee_type without selection

The field selection was being evaluated at model setup time before the class was fully initialized. Using a method reference provides lazy evaluation, resolving the Odoo 19 compatibility issue.

Changes:
- Added _get_employee_type_selection() method for lazy evaluation
- Changed selection parameter from list to method reference string

https://claude.ai/code/session_01VorxKDuZ4kGs7KQuMj8eDd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the employee type selection mechanism for enhanced system flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->