### PR TITLE
[MIG] survey_contact_generation: replace hr.candidate with hr.applicant for Odoo 19

### DIFF
--- a/survey_contact_generation/models/__init__.py
+++ b/survey_contact_generation/models/__init__.py
@@ -3,4 +3,3 @@ from . import survey_question
 from . import survey_survey
 from . import survey_user_input
 from . import hr_applicant
-from . import hr_candidate

--- a/survey_contact_generation/models/hr_candidate.py
+++ b/survey_contact_generation/models/hr_candidate.py
@@ -1,9 +1,0 @@
-from odoo import fields, models
-
-
-class HrCandidate(models.Model):
-    _inherit = "hr.candidate"
-
-    generating_survey_user_input_id = fields.Many2one(
-        comodel_name="survey.user_input", copy=False, readonly=True
-    )

--- a/survey_contact_generation/models/survey_question.py
+++ b/survey_contact_generation/models/survey_question.py
@@ -92,7 +92,7 @@ class SurveyQuestion(models.Model):
         for record in self:
             allowed_types = type_mapping.get(record.question_type, [])
             domain = [
-                ("model", "=", "hr.candidate"),
+                ("model", "=", "hr.applicant"),
                 ("ttype", "in", allowed_types),
                 ("store", "=", True),
                 ("readonly", "=", False),

--- a/survey_contact_generation/views/survey_question_views.xml
+++ b/survey_contact_generation/views/survey_question_views.xml
@@ -16,6 +16,7 @@
                         domain="allowed_applicant_field_domain"
                         invisible="parent.generation_type != 'applicant'"/>
                     <field name="hr_candidate_field"
+                        string="Applicant field (extra)"
                         options="{'no_create': True, 'no_open': True}"
                         domain="allowed_candidate_field_domain"
                         invisible="parent.generation_type != 'applicant'"/>
@@ -57,10 +58,9 @@
                          invisible="parent.generation_type != 'applicant'">
                         <strong>Attenzione:</strong> 
                         <ul>
-                            <li><strong>Candidate field:</strong> Campo del candidato (hr.candidate)</li>
                             <li><strong>Applicant field:</strong> Campo della candidatura (hr.applicant)</li>
+                            <li><strong>Applicant field (extra):</strong> Campo aggiuntivo della candidatura (hr.applicant)</li>
                             <li>Non è possibile mappare la stessa domanda su entrambi i tipi di campo.</li>
-                            <li>Assicurarsi di mappare il nome del candidato per la creazione corretta.</li>
                         </ul>
                     </div>
                 </group>


### PR DESCRIPTION
In Odoo 19, hr.candidate was removed and replaced by the talent pool
system (hr.talent.pool). All candidate fields (partner_name, email_from,
availability, etc.) are now directly on hr.applicant.

Changes:
- Remove models/hr_candidate.py (_inherit "hr.candidate" caused TypeError)
- Redirect candidate field domain from hr.candidate to hr.applicant
- Remove _get_or_create_candidate() method (no more hr.candidate creation)
- Rename _prepare_candidate() to _prepare_candidate_as_applicant()
- Simplify _mark_done() to merge candidate-mapped values into applicant
- Update view labels: "Candidate field" → "Applicant field (extra)"

https://claude.ai/code/session_013NBzS782nh8LNW9mGv7fLg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified survey workflow to focus exclusively on applicant creation, removing the candidate creation pathway
  * Updated UI labels and field descriptions to reflect applicant-focused workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->